### PR TITLE
feat(ui): weekly rate chart + interactions and converter layout polish

### DIFF
--- a/src/app/api/timeseries/route.ts
+++ b/src/app/api/timeseries/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { getSeriesWithFallback } from '@/server/rates/timeseries';
+import type { Currency } from '@/core/money';
+
+const SUPPORTED = new Set<Currency>(['USD', 'EUR', 'BRL']);
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const from = (searchParams.get('from') ?? 'USD').toUpperCase() as Currency;
+  const to = (searchParams.get('to') ?? 'BRL').toUpperCase() as Currency;
+  const days = Number(searchParams.get('days') ?? 7);
+
+  if (!SUPPORTED.has(from) || !SUPPORTED.has(to) || !Number.isFinite(days)) {
+    return NextResponse.json({ error: 'Invalid params' }, { status: 400 });
+  }
+
+  try {
+    const { points, meta } = await getSeriesWithFallback(from, to, days);
+    return NextResponse.json({ series: points, meta });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch timeseries' }, { status: 502 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,15 +10,14 @@ import { convert } from '@/core/convert';
 import type { Currency } from '@/core/money';
 import { StaticRateProvider } from '@/providers/static';
 import { HttpRateProvider } from '@/providers/http';
-
 import type { RateWithMeta } from '@/providers/types';
-
 import { ClientErrorBoundary } from '@/components/ClientErrorBoundary';
 import { logger } from '@/lib/logger';
-
 import { useToast } from '@/components/ToastProvider';
-
 import FeatureCard from '@/components/FeatureCard';
+
+import RateChart from '@/components/RateChart';
+import Modal from '@/components/Modal';
 
 
 import {
@@ -41,6 +40,7 @@ export default function Home() {
   const [useDynamic, setUseDynamic] = useState(true);
   const [attributionUrl, setAttributionUrl] = useState<string | null>(null);
   const { toast } = useToast();
+  const [chartOpen, setChartOpen] = useState(false);
 
   function handleAmountChange(v: string) {
     const cleaned = normalizeAmountInput(v);
@@ -195,8 +195,8 @@ export default function Home() {
           {/* CONVERSOR */}
           <section id="converter" className="section">
             <div className="container">
-              <div className="grid gap-6 md:grid-cols-2 items-start">
-                <div className="card p-5">
+              <div className="grid gap-6 md:grid-cols-2 md:items-stretch">
+                <div className="card p-5 h-full flex flex-col">
                   <h2 className="text-xl sm:text-2xl font-semibold mb-2">Conversor</h2>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Informe o valor, escolha as moedas e clique em converter.
@@ -297,6 +297,28 @@ export default function Home() {
                       </a>
                     </p>
                   )}
+                </div>
+
+                {/* Ações extras */}
+                <div className="mt-3 md:hidden">
+                  <button
+                    onClick={() => setChartOpen(true)}
+                    className="h-10 px-4 rounded-lg border border-[color:var(--border)] 
+                    hover:bg-[var(--background-secondary)] focus-visible:ring-2 
+                    focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 cursor-pointer"
+                  >
+                    Ver gráfico (7d)
+                  </button>
+                </div>
+
+                <Modal open={chartOpen} onClose={() => setChartOpen(false)} title="Taxa">
+                  <RateChart from={from} to={to} days={7} />
+                </Modal>
+
+                {/* CARD: Gráfico (desktop) */}
+                <div className="hidden md:block card p-5 h-full">
+                  <h3 className="text-base font-semibold mb-2">Taxa</h3>
+                  <RateChart from={from} to={to} days={7} />
                 </div>
 
                 <div className="card p-5">

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Modal({
+  open, onClose, children, title = 'Gráfico (7 dias)',
+}: { open: boolean; onClose: () => void; children: React.ReactNode; title?: string; }) {
+  useEffect(() => {
+    function onEsc(e: KeyboardEvent) { if (e.key === 'Escape') onClose(); }
+    if (open) document.addEventListener('keydown', onEsc);
+    return () => document.removeEventListener('keydown', onEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div role="dialog" aria-modal="true" className="relative z-10 card w-full max-w-xl p-5 bg-[var(--surface)]">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-base font-semibold">{title}</h3>
+          <button
+            onClick={onClose}
+            className="cursor-pointer text-red-600 h-9 px-3 rounded-lg border border-red-600 
+            hover:bg-[var(--background-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] 
+            focus-visible:ring-offset-2"
+          >
+            Fechar
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RateChart.tsx
+++ b/src/components/RateChart.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Currency } from '@/core/money';
+import Skeleton from './Skeleton';
+
+type Props = { from: Currency; to: Currency; days?: number; height?: number };
+type Point = { date: string; value: number };
+type Meta = { provider: 'yahoo' | 'frankfurter'; granularity: 'intraday' | 'daily' };
+
+export default function RateChart({ from, to, days = 7, height = 160 }: Props) {
+  const [loading, setLoading] = useState(true);
+  const [points, setPoints] = useState<Point[]>([]);
+  const [meta, setMeta] = useState<Meta | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // interação
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const w = 360;
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    fetch(`/api/timeseries?from=${from}&to=${to}&days=${days}`, { cache: 'no-store' })
+      .then(async (r) => {
+        if (!r.ok) throw new Error('timeseries http');
+        return (await r.json()) as { series: Point[]; meta: Meta };
+      })
+      .then((json) => {
+        if (!alive) return;
+        setPoints(json.series);
+        setMeta(json.meta);
+        setError(null);
+      })
+      .catch(() => { if (alive) setError('Sem dados no momento.'); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [from, to, days]);
+
+  const calc = useMemo(() => {
+    if (!points.length) {
+      return {
+        path: '', area: '', min: 0, max: 0, first: null as Point | null, last: null as Point | null,
+        startLabel: '', endLabel: '', xs: [] as number[], ys: [] as number[],
+      };
+    }
+    const h = height;
+    const minV = Math.min(...points.map((p) => p.value));
+    const maxV = Math.max(...points.map((p) => p.value));
+    const padY = (maxV - minV) * 0.1 || 0.01;
+    const lo = minV - padY;
+    const hi = maxV + padY;
+
+    const denom = Math.max(1, points.length - 1);
+    const sx = (i: number) => (i / denom) * (w - 8) + 4;
+    const sy = (v: number) => {
+      const t = (v - lo) / (hi - lo);
+      return h - 12 - t * (h - 24);
+    };
+
+    const xs: number[] = [];
+    const ys: number[] = [];
+    const segs: string[] = [];
+
+    points.forEach((p, i) => {
+      const x = sx(i);
+      const y = sy(p.value);
+      xs.push(x); ys.push(y);
+      segs.push(`${i === 0 ? 'M' : 'L'} ${x} ${y}`);
+    });
+
+    const path = segs.join(' ');
+    const area = `M 4 ${h - 12} ${segs.join(' ').replace(/^M[^L]*/, '')} L ${sx(points.length - 1)} ${h - 12} Z`;
+
+    return {
+      path, area,
+      min: minV, max: maxV,
+      first: points[0], last: points[points.length - 1],
+      startLabel: points[0]?.date.slice(0, 10), endLabel: points[points.length - 1]?.date.slice(0, 10),
+      xs, ys,
+    };
+  }, [points, height]);
+
+  function onMove(e: React.MouseEvent<SVGSVGElement>) {
+    if (!svgRef.current || !points.length) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const clientX = e.clientX - rect.left;
+    const xInView = Math.max(0, Math.min(rect.width, clientX));
+    const x = (xInView / rect.width) * w;
+
+    // índice aproximado pelo inverso de sx
+    const denom = Math.max(1, points.length - 1);
+    const i = Math.round(((x - 4) / (w - 8)) * denom);
+    const clamped = Math.max(0, Math.min(points.length - 1, i));
+    setHoverIdx(clamped);
+  }
+  function onLeave() {
+    setHoverIdx(null); // tooltip some ao sair do gráfico
+  }
+
+  if (loading) {
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <Skeleton className="h-5 w-48 rounded" />
+          <Skeleton className="h-5 w-20 rounded" />
+        </div>
+        <Skeleton className="h-40 w-full rounded" />
+      </div>
+    );
+  }
+
+  if (error || !points.length || !meta) {
+    return <div className="text-sm text-[var(--text-secondary)]">{error ?? 'Sem dados.'}</div>;
+  }
+
+  const { path, area, min, max, first, last, startLabel, endLabel, xs, ys } = calc;
+  const change = last && first ? ((last.value - first.value) / first.value) * 100 : 0;
+  const changeLabel = `${change >= 0 ? '▲' : '▼'} ${Math.abs(change).toFixed(2)}%`;
+  const providerLabel =
+    meta.provider === 'yahoo' ? 'Yahoo (intraday)' : 'Frankfurter (diário – apenas dias úteis)';
+
+  const show = hoverIdx !== null ? points[hoverIdx] : null;
+  const showX = hoverIdx !== null ? xs[hoverIdx] : 0;
+
+  return (
+    <div className="relative">
+      {/* Cabeçalho em duas linhas */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm">
+          <div className="font-medium">Taxa {from} → {to}</div>
+          <div>
+            <span className="font-medium">Últimos {days} dias</span>{' '}
+            <span className="text-[var(--text-secondary)]">({startLabel} → {endLabel})</span>
+          </div>
+        </div>
+        <div className={`text-sm ${change >= 0 ? 'text-green-600' : 'text-red-600'}`}>{changeLabel}</div>
+      </div>
+
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${w} ${height}`}
+        className="w-full h-auto"
+        onMouseMove={onMove}
+        onMouseLeave={onLeave}
+      >
+        <path d={area} fill="rgba(0,60,95,0.10)" />
+        <path d={path} stroke="rgb(0,60,95)" strokeWidth="2" fill="none" />
+
+        {hoverIdx !== null && (
+          <>
+            <line
+              x1={showX} y1={12}
+              x2={showX} y2={height - 12}
+              stroke="rgba(0,60,95,0.4)" strokeWidth="1"
+            />
+            <circle
+              cx={showX} cy={ys[hoverIdx]} r="4"
+              fill="rgb(0,60,95)" stroke="#fff" strokeWidth="1.5"
+            />
+          </>
+        )}
+      </svg>
+
+      {/* Tooltip: visível apenas durante o hover */}
+      {hoverIdx !== null && show && (
+        <div
+          className="absolute pointer-events-none text-xs bg-white/95 border border-[color:var(--border)] rounded px-2 py-1 shadow-sm"
+          style={{
+            left: `calc(min(100% - 140px, max(0px, ${(showX / w) * 100}% - 70px)))`,
+            top: 10,
+          }}
+        >
+          <div className="font-medium">{from} → {to}</div>
+          <div>Valor: {show.value.toFixed(6)}</div>
+          <div className="text-[var(--text-secondary)]">{show.date}</div>
+        </div>
+      )}
+
+      <div className="mt-2 grid grid-cols-3 text-xs text-[var(--text-secondary)]">
+        <div>Mín: {min.toFixed(4)}</div>
+        <div className="text-center">Atual: {last?.value.toFixed(4)}</div>
+        <div className="text-right">Máx: {max.toFixed(4)}</div>
+      </div>
+
+      <div className="mt-2 text-xs text-[var(--text-secondary)]">
+        Fonte: <span className="font-medium">{providerLabel}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/server/rates/timeseries.ts
+++ b/src/server/rates/timeseries.ts
@@ -1,0 +1,141 @@
+import { env } from '@/env/server';
+import type { Currency } from '@/core/money';
+
+export type RatePoint = { date: string; value: number };
+export type SeriesMeta = { provider: 'yahoo' | 'frankfurter'; granularity: 'intraday' | 'daily' };
+
+/* Tipos mínimos para a resposta do Yahoo Finance (chart API) */
+type YahooQuote = { close?: Array<number | null> };
+type YahooIndicators = { quote?: YahooQuote[] };
+type YahooResult = { timestamp?: number[]; indicators?: YahooIndicators };
+type YahooChartResponse = { chart?: { result?: YahooResult[] } };
+
+// Helpers de narrowing
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+function hasProp<K extends PropertyKey>(o: unknown, k: K): o is Record<K, unknown> {
+  return isObject(o) && k in o;
+}
+
+function isYahooChartResponse(x: unknown): x is YahooChartResponse {
+  if (!hasProp(x, 'chart')) return false;
+  const chart = x.chart; // chart: unknown
+  if (!hasProp(chart, 'result')) return false;
+  const result = chart.result; // result: unknown
+  if (!Array.isArray(result) || !result.length) return false;
+  return true;
+}
+
+function formatDateUTC(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = `${d.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${d.getUTCDate()}`.padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+function addDaysUTC(d: Date, days: number): Date {
+  const copy = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+async function withTimeout<T>(fn: (signal: AbortSignal) => Promise<T>, ms = 4000) {
+  const ctrl = new AbortController();
+  const id = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fn(ctrl.signal);
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+function yahooSymbol(from: Currency, to: Currency): { symbol: string; invert: boolean } {
+  const map: Record<string, { symbol: string; invert: boolean }> = {
+    'USD->BRL': { symbol: 'USDBRL=X', invert: false },
+    'BRL->USD': { symbol: 'USDBRL=X', invert: true },
+    'EUR->BRL': { symbol: 'EURBRL=X', invert: false },
+    'BRL->EUR': { symbol: 'EURBRL=X', invert: true },
+    'EUR->USD': { symbol: 'EURUSD=X', invert: false },
+    'USD->EUR': { symbol: 'EURUSD=X', invert: true },
+  };
+  return map[`${from}->${to}`] ?? { symbol: `${from}${to}=X`, invert: false };
+}
+
+/** Série intraday do Yahoo (sem chave) */
+async function yahooIntraday(
+  from: Currency,
+  to: Currency,
+  days: number,
+  signal?: AbortSignal
+): Promise<{ points: RatePoint[] }> {
+  const { symbol, invert } = yahooSymbol(from, to);
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(
+    symbol
+  )}?range=${Math.max(1, days)}d&interval=60m`;
+
+  const res = await fetch(url, { signal, cache: 'no-store' });
+  if (!res.ok) throw new Error(`Yahoo HTTP ${res.status}`);
+
+  const json: unknown = await res.json();
+  if (!isYahooChartResponse(json)) throw new Error('Yahoo: unexpected shape');
+
+  const result = json.chart!.result![0];
+  const ts = result.timestamp ?? [];
+  const closes = result.indicators?.quote?.[0]?.close ?? [];
+
+  if (!Array.isArray(ts) || !Array.isArray(closes) || ts.length !== closes.length) {
+    throw new Error('Yahoo: invalid series');
+  }
+
+  const points: RatePoint[] = [];
+  for (let i = 0; i < ts.length; i++) {
+    const v = closes[i];
+    if (v == null || !Number.isFinite(v)) continue;
+    const val = invert ? 1 / Number(v) : Number(v);
+    const date = new Date(ts[i] * 1000).toISOString().slice(0, 16).replace('T', ' ');
+    points.push({ date, value: val });
+  }
+  if (!points.length) throw new Error('Yahoo: empty');
+  return { points };
+}
+
+/** Série diária do Frankfurter (ECB) — apenas dias úteis */
+async function frankfurterDaily(
+  from: Currency,
+  to: Currency,
+  days: number,
+  signal?: AbortSignal
+): Promise<{ points: RatePoint[] }> {
+  const end = new Date();
+  const start = addDaysUTC(end, -(Math.max(1, days) - 1));
+  const base = env.FRANKFURTER_BASE;
+  const url = `${base}/${formatDateUTC(start)}..${formatDateUTC(end)}?from=${from}&to=${to}`;
+
+  const res = await fetch(url, { signal, cache: 'no-store' });
+  if (!res.ok) throw new Error(`Frankfurter timeseries HTTP ${res.status}`);
+
+  const data = (await res.json()) as { rates?: Record<string, Record<string, number>> };
+  const rates = data.rates ?? {};
+  const points = Object.keys(rates)
+    .sort()
+    .map((date) => ({ date, value: Number(rates[date]?.[to]) }))
+    .filter((p) => Number.isFinite(p.value));
+
+  if (!points.length) throw new Error('Frankfurter: empty');
+  return { points };
+}
+
+export async function getSeriesWithFallback(
+  from: Currency,
+  to: Currency,
+  days = 7,
+  timeoutMs = 4000
+): Promise<{ points: RatePoint[]; meta: SeriesMeta }> {
+  try {
+    const { points } = await withTimeout((signal) => yahooIntraday(from, to, days, signal), timeoutMs);
+    return { points, meta: { provider: 'yahoo', granularity: 'intraday' } };
+  } catch {
+    // fallback
+  }
+  const { points } = await withTimeout((signal) => frankfurterDaily(from, to, days, signal), timeoutMs);
+  return { points, meta: { provider: 'frankfurter', granularity: 'daily' } };
+}


### PR DESCRIPTION
• API /api/timeseries: Yahoo Finance intraday (sem chave) com fallback Frankfurter diário; tipos seguros

• RateChart: tooltip/hover, linha guia, cabeçalho em duas linhas, par explícito {from}→{to}, label de provedor

• Conversor (desktop): grid 4 colunas [2fr auto 1fr 1fr], hint sob Valor, correção de overflow (min-w-0) e w-full

• Alturas iguais dos cards (converter e gráfico) com md:items-stretch + h-full

• Modal no mobile p/ gráfico; card no desktop; ajustes visuais e de acessibilidade