### PR TITLE
feat: moedas fiat+cripto, provider dinâmico no servidor e correções n…

### DIFF
--- a/src/app/api/timeseries/route.ts
+++ b/src/app/api/timeseries/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getSeriesWithFallback } from '@/server/rates/timeseries';
-import type { Currency } from '@/core/money';
+import { ALL_CURRENCIES, type Currency } from '@/core/money';
 
-const SUPPORTED = new Set<Currency>(['USD', 'EUR', 'BRL']);
+const SUPPORTED = new Set<Currency>(ALL_CURRENCIES);
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);

--- a/src/components/CurrencySelect.tsx
+++ b/src/components/CurrencySelect.tsx
@@ -1,31 +1,30 @@
 'use client';
-import { useId } from 'react';
-import type { Currency } from '@/core/money';
-import { SUPPORTED_CURRENCIES } from '@/core/money';
+import { FIAT_CURRENCIES, CRYPTO_CURRENCIES, currencyLabel, Currency } from '@/core/money';
 
-type Props = {
-  label: string;
-  value: Currency;
-  onChange: (c: Currency) => void;
-};
-
-export default function CurrencySelect({ label, value, onChange }: Props) {
-  const id = useId();
+export default function CurrencySelect({
+  label, value, onChange,
+}: { label: string; value: Currency; onChange: (v: Currency) => void }) {
   return (
-    <div className="flex flex-col gap-1">
-      <label htmlFor={id} className="text-sm font-medium">{label}</label>
+    <label className="flex flex-col gap-1">
+      <span className="text-sm">{label}</span>
       <select
-        id={id}
-        className="border rounded-lg h-11 px-3 text-base sm:text-lg outline-none 
-          border-[color:var(--border)] text-[var(--text-primary)] 
-          focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2"
         value={value}
         onChange={(e) => onChange(e.target.value as Currency)}
+        className="w-full border rounded-lg h-11 px-3 text-base sm:text-lg outline-none 
+                   border-[color:var(--border)] text-[var(--text-primary)]
+                   focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2"
       >
-        {SUPPORTED_CURRENCIES.map((c) => (
-          <option key={c} value={c}>{c}</option>
-        ))}
+        <optgroup label="Moedas (fiat)">
+          {FIAT_CURRENCIES.map(c => (
+            <option key={c} value={c}>{currencyLabel(c)}</option>
+          ))}
+        </optgroup>
+        <optgroup label="Criptomoedas">
+          {CRYPTO_CURRENCIES.map(c => (
+            <option key={c} value={c}>{currencyLabel(c)}</option>
+          ))}
+        </optgroup>
       </select>
-    </div>
+    </label>
   );
 }

--- a/src/core/money.ts
+++ b/src/core/money.ts
@@ -1,9 +1,37 @@
-export type Currency = 'USD' | 'EUR' | 'BRL';
+export type Currency =
+  | 'USD' | 'EUR' | 'BRL'
+  | 'GBP' | 'JPY' | 'CAD' | 'AUD' | 'CHF'
+  | 'BTC' | 'ETH' | 'USDT';
 
-export const SUPPORTED_CURRENCIES: Currency[] = ['USD', 'EUR', 'BRL'];
+export const FIAT_CURRENCIES: Currency[] = [
+  'USD', 'EUR', 'BRL', 'GBP', 'JPY', 'CAD', 'AUD', 'CHF',
+];
 
-export type Rate = {
-  from: Currency;
-  to: Currency;
-  value: string;
+export const CRYPTO_CURRENCIES: Currency[] = ['BTC', 'ETH', 'USDT'];
+
+export const ALL_CURRENCIES: Currency[] = [...FIAT_CURRENCIES, ...CRYPTO_CURRENCIES];
+
+export function isCrypto(c: Currency): boolean {
+  return (CRYPTO_CURRENCIES as string[]).includes(c);
+}
+
+const NAMES: Record<Currency, string> = {
+  USD: 'Dólar americano',
+  EUR: 'Euro',
+  BRL: 'Real brasileiro',
+  GBP: 'Libra esterlina',
+  JPY: 'Iene japonês',
+  CAD: 'Dólar canadense',
+  AUD: 'Dólar australiano',
+  CHF: 'Franco suíço',
+  BTC: 'Bitcoin',
+  ETH: 'Ethereum',
+  USDT: 'Tether (USDt)',
 };
+
+export function currencyLabel(c: Currency): string {
+  return isCrypto(c) ? `${c} · CRYPTO` : `${c}`;
+}
+export function currencyLongLabel(c: Currency): string {
+  return isCrypto(c) ? `${c} — ${NAMES[c]} (CRYPTO)` : `${c} — ${NAMES[c]}`;
+}

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -1,20 +1,22 @@
+'use client';
+
 import type { Currency } from '@/core/money';
-import type { RateWithMeta } from './types';
+
+export type RateWithMeta = {
+  value: number;
+  provider: 'frankfurter' | 'open-er-api' | 'currency-api';
+  attributionUrl?: string | null;
+};
 
 export const HttpRateProvider = {
   async getRate(from: Currency, to: Currency, signal?: AbortSignal): Promise<RateWithMeta> {
-    const res = await fetch(`/api/rate?from=${from}&to=${to}`, {
-      signal,
-      cache: 'no-store',
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    return {
-      from,
-      to,
-      value: String(data.rate),
-      provider: data.provider ?? undefined,
-      attributionUrl: data.attributionUrl ?? null,
-    };
+    const url = `/api/rate?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+    const res = await fetch(url, { signal, cache: 'no-store' });
+    if (!res.ok) {
+      throw new Error(`rate http ${res.status}`);
+    }
+    const json = (await res.json()) as RateWithMeta;
+    if (!Number.isFinite(json.value)) throw new Error('rate invalid');
+    return json;
   },
 };

--- a/src/providers/static.ts
+++ b/src/providers/static.ts
@@ -1,26 +1,56 @@
 import type { Currency } from '@/core/money';
-import type { RateWithMeta } from './types';
 
 /**
- * Mapa de taxa para BRL como base (exemplo).
+ * Fallback estático: tabela "unidades da moeda POR 1 USD".
+ * Para FIAT: os valores são estáveis o suficiente como aproximação.
+ * Para CRYPTO: valores são APROXIMADOS (apenas para desbloquear o fluxo em caso de falha de rede),
+ * NÃO representam preço de mercado atual.
+ *
+ * Ex.: BRL: 5.40  => 1 USD = 5.40 BRL
+ *      EUR: 0.92  => 1 USD = 0.92 EUR
+ *      BTC: ~1/65000 => 1 USD ≈ 0.00001538 BTC (aprox.)
+ *      ETH: ~1/3000  => 1 USD ≈ 0.00033333 ETH (aprox.)
+ *      USDT: 1      => 1 USD = 1 USDT
  */
-const RATE_TO_BRL: Record<Currency, number> = {
-  BRL: 1,
-  USD: 0.18419,
-  EUR: 0.1576,
-};
 
-function crossRate(from: Currency, to: Currency): string {
-  if (from === to) return '1';
-  const toBRL = RATE_TO_BRL[to];
-  const fromBRL = RATE_TO_BRL[from];
-  if (!toBRL || !fromBRL) throw new Error('Unsupported currency');
-  return String(toBRL / fromBRL);
-}
+// FIAT
+const USD_BASE_FIAT = {
+  USD: 1,
+  EUR: 0.92,
+  BRL: 5.40,
+  GBP: 0.78,
+  JPY: 157,
+  CAD: 1.36,
+  AUD: 1.48,
+  CHF: 0.86,
+} as const;
+
+// CRYPTO (aproximado; apenas para fallback)
+const USD_BASE_CRYPTO = {
+  BTC: 1 / 65000,     // ≈ 0.00001538 BTC por 1 USD
+  ETH: 1 / 3000,      // ≈ 0.00033333 ETH por 1 USD
+  USDT: 1,            // 1 USD ≈ 1 USDT
+} as const;
+
+const USD_BASE: Record<Currency, number> = {
+  ...USD_BASE_FIAT,
+  ...USD_BASE_CRYPTO,
+} as unknown as Record<Currency, number>;
+
+export type StaticRate = { value: number; provider?: string };
 
 export const StaticRateProvider = {
-  getRate(from: Currency, to: Currency): RateWithMeta {
-    // provider/attributionUrl são opcionais; no estático deixamos indefinidos
-    return { from, to, value: crossRate(from, to) };
+  /**
+   * Converte via razão (to / from) usando a base USD:
+   * rate(from→to) = USD_BASE[to] / USD_BASE[from]
+   */
+  getRate(from: Currency, to: Currency): StaticRate {
+    if (from === to) return { value: 1, provider: 'static' };
+    const f = USD_BASE[from];
+    const t = USD_BASE[to];
+    if (!Number.isFinite(f) || !Number.isFinite(t)) {
+      throw new Error('Static fallback: pair not supported');
+    }
+    return { value: t / f, provider: 'static' };
   },
 };

--- a/src/server/rates/latest.ts
+++ b/src/server/rates/latest.ts
@@ -1,0 +1,150 @@
+// src/server/rates/latest.ts
+import 'server-only';
+import { env } from '@/env/server';
+import { type Currency, CRYPTO_CURRENCIES } from '@/core/money';
+
+export type RateWithMeta = {
+  value: number;
+  provider: 'frankfurter' | 'open-er-api' | 'currency-api';
+  attributionUrl?: string | null;
+};
+
+function isCrypto(c: Currency) {
+  return (CRYPTO_CURRENCIES as readonly string[]).includes(c);
+}
+
+async function withTimeout<T>(fn: (signal: AbortSignal) => Promise<T>, ms = 4500): Promise<T> {
+  const ctrl = new AbortController();
+  const id = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fn(ctrl.signal);
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+/* ---------- FRANKFURTER (FIAT apenas) ---------- */
+async function getFrankfurter(from: Currency, to: Currency, signal?: AbortSignal): Promise<RateWithMeta> {
+  const base = env.FRANKFURTER_BASE; // ex: https://api.frankfurter.dev/v1
+  const url = `${base}/latest?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+  const res = await fetch(url, { signal, cache: 'no-store' });
+  if (!res.ok) throw new Error(`Frankfurter HTTP ${res.status}`);
+  const json: unknown = await res.json();
+  const rate = (json as { rates?: Record<string, number> })?.rates?.[to];
+  if (!Number.isFinite(rate)) throw new Error('Frankfurter: missing rate');
+  return { value: Number(rate), provider: 'frankfurter', attributionUrl: null };
+}
+
+/* ---------- OPEN ER-API (FIAT) ---------- */
+async function getOpenER(from: Currency, to: Currency, signal?: AbortSignal): Promise<RateWithMeta> {
+  const base = env.OPEN_ER_API_BASE; // ex: https://open.er-api.com/v6
+  const url = `${base}/latest/${encodeURIComponent(from)}`;
+  const res = await fetch(url, { signal, cache: 'no-store' });
+  if (!res.ok) throw new Error(`Open ER-API HTTP ${res.status}`);
+  const json: unknown = await res.json();
+
+  const dict =
+    (json as { rates?: Record<string, number> })?.rates ??
+    (json as { conversion_rates?: Record<string, number> })?.conversion_rates;
+
+  const rate = dict?.[to];
+  if (!Number.isFinite(rate)) throw new Error('Open ER-API: missing rate');
+  return {
+    value: Number(rate),
+    provider: 'open-er-api',
+    attributionUrl: 'https://www.exchangerate-api.com',
+  };
+}
+
+/* ---------- CURRENCY-API (CDN) — FIAT e CRYPTO ---------- */
+async function parseCurrencyApiPair(
+  from: string,
+  to: string,
+  json: unknown
+): Promise<number | null> {
+  // A) { date, [to]: number }  B) { date, [from]: { [to]: number } }
+  if (json && typeof json === 'object') {
+    const obj = json as Record<string, unknown>;
+    const flat = obj[to];
+    if (typeof flat === 'number') return flat;
+    const nested = obj[from];
+    if (nested && typeof nested === 'object') {
+      const val = (nested as Record<string, unknown>)[to];
+      if (typeof val === 'number') return val;
+    }
+  }
+  return null;
+}
+
+async function getCurrencyApi(from: Currency, to: Currency, signal?: AbortSignal): Promise<RateWithMeta> {
+  // Bases em ordem de preferência (1: npm – novo; 2: gh – legado)
+  const bases = [
+    env.CURRENCY_API_CDN_BASE?.replace(/\/+$/, ''),
+    'https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies',
+    'https://cdn.jsdelivr.net/gh/fawazahmed0/currency-api@1/latest/currencies',
+  ].filter(Boolean) as string[];
+
+  const f = from.toLowerCase();
+  const t = to.toLowerCase();
+
+  // tenta cada base até obter um rate válido
+  for (const base of bases) {
+    // 1) endpoint do par: .../f/t.json
+    try {
+      const pairUrl = `${base}/${encodeURIComponent(f)}/${encodeURIComponent(t)}.json`;
+      const r1 = await fetch(pairUrl, { signal, cache: 'no-store' });
+      if (r1.ok) {
+        const j1: unknown = await r1.json();
+        const rate1 = await parseCurrencyApiPair(f, t, j1);
+        if (Number.isFinite(rate1)) {
+          return { value: Number(rate1), provider: 'currency-api', attributionUrl: null };
+        }
+      }
+    } catch {
+      // segue para tentativa 2
+    }
+
+    // 2) endpoint do "from": .../f.json  (mapa completo)
+    try {
+      const mapUrl = `${base}/${encodeURIComponent(f)}.json`;
+      const r2 = await fetch(mapUrl, { signal, cache: 'no-store' });
+      if (r2.ok) {
+        const j2: unknown = await r2.json();
+        const dict = (j2 as Record<string, unknown>)[f];
+        const rate2 = dict && typeof dict === 'object' ? (dict as Record<string, unknown>)[t] : undefined;
+        if (Number.isFinite(rate2 as number)) {
+          return { value: Number(rate2), provider: 'currency-api', attributionUrl: null };
+        }
+      }
+    } catch {
+      // tenta próxima base
+    }
+  }
+
+  throw new Error('Currency-API: missing rate (all bases)');
+}
+
+
+/* ---------- API pública do servidor ---------- */
+export async function getLatestRateWithFallback(
+  from: Currency,
+  to: Currency,
+  abortSignal?: AbortSignal
+): Promise<RateWithMeta> {
+  if (from === to) return { value: 1, provider: 'frankfurter', attributionUrl: null };
+
+  const hasCrypto = isCrypto(from) || isCrypto(to);
+
+  if (hasCrypto) {
+    // Somente Currency-API atende cripto sem chave
+    return withTimeout((signal) => getCurrencyApi(from, to, abortSignal ?? signal));
+  }
+
+  try {
+    return await withTimeout((signal) => getFrankfurter(from, to, abortSignal ?? signal));
+  } catch {}
+  try {
+    return await withTimeout((signal) => getOpenER(from, to, abortSignal ?? signal));
+  } catch {}
+  return withTimeout((signal) => getCurrencyApi(from, to, abortSignal ?? signal));
+}

--- a/src/server/rates/timeseries.ts
+++ b/src/server/rates/timeseries.ts
@@ -49,6 +49,16 @@ async function withTimeout<T>(fn: (signal: AbortSignal) => Promise<T>, ms = 4000
 }
 
 function yahooSymbol(from: Currency, to: Currency): { symbol: string; invert: boolean } {
+  const CRYPTO = new Set<Currency>(['BTC', 'ETH', 'USDT']);
+
+  // Caso envolva cripto: usamos padrão "CRYPTO-FIAT"
+  if (CRYPTO.has(from) || CRYPTO.has(to)) {
+    const crypto = CRYPTO.has(from) ? from : to;
+    const fiat = CRYPTO.has(from) ? to : from;
+    return { symbol: `${crypto}-${fiat}`, invert: CRYPTO.has(to) }; // invert quando TO é cripto
+  }
+
+  // Forex tradicional
   const map: Record<string, { symbol: string; invert: boolean }> = {
     'USD->BRL': { symbol: 'USDBRL=X', invert: false },
     'BRL->USD': { symbol: 'USDBRL=X', invert: true },
@@ -56,8 +66,25 @@ function yahooSymbol(from: Currency, to: Currency): { symbol: string; invert: bo
     'BRL->EUR': { symbol: 'EURBRL=X', invert: true },
     'EUR->USD': { symbol: 'EURUSD=X', invert: false },
     'USD->EUR': { symbol: 'EURUSD=X', invert: true },
+
+    'USD->GBP': { symbol: 'USDGBP=X', invert: false }, // Yahoo aceita várias formas; fallback genérico abaixo cobre
+    'GBP->USD': { symbol: 'USDGBP=X', invert: true },
+    'USD->JPY': { symbol: 'USDJPY=X', invert: false },
+    'JPY->USD': { symbol: 'USDJPY=X', invert: true },
+    'USD->CAD': { symbol: 'USDCAD=X', invert: false },
+    'CAD->USD': { symbol: 'USDCAD=X', invert: true },
+    'USD->AUD': { symbol: 'USDAUD=X', invert: false },
+    'AUD->USD': { symbol: 'USDAUD=X', invert: true },
+    'USD->CHF': { symbol: 'USDCHF=X', invert: false },
+    'CHF->USD': { symbol: 'USDCHF=X', invert: true },
+    'EUR->GBP': { symbol: 'EURGBP=X', invert: false },
+    'GBP->EUR': { symbol: 'EURGBP=X', invert: true },
   };
-  return map[`${from}->${to}`] ?? { symbol: `${from}${to}=X`, invert: false };
+  const key = `${from}->${to}`;
+  if (map[key]) return map[key];
+
+  // fallback genérico para pares forex
+  return { symbol: `${from}${to}=X`, invert: false };
 }
 
 /** Série intraday do Yahoo (sem chave) */


### PR DESCRIPTION
…o gráfico/UI

currency: add GBP/JPY/CAD/AUD/CHF e BTC/ETH/USDT; CurrencySelect com grupos e tag CRYPTO

provider(dynamic): mover lógica para o servidor (/api/rate) p/ evitar 'server-only' em client

provider(dynamic): Currency-API via jsDelivr npm path com fallback p/ GH; robust parsing

provider(static): fallback USD-base passa a cobrir FIAT↔CRYPTO (aprox. p/ cripto)

chart: header em duas linhas, tooltip só no hover; intraday Yahoo→Frankfurter diário

ui(conversor): grid [2fr auto 1fr 1fr], min-w-0 + w-full; cards com mesma altura (md:items-stretch + h-full)

env: CURRENCY_API_CDN_BASE atualizado p/ npm path (@latest/v1/currencies)